### PR TITLE
Exclude vehicles with known-invalid locations unless explicitly requested

### DIFF
--- a/docs/superpowers/plans/2026-08-11-invalid-vehicle-locations.md
+++ b/docs/superpowers/plans/2026-08-11-invalid-vehicle-locations.md
@@ -1,0 +1,739 @@
+# Invalid Vehicle Locations Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Vehicles reported at known-invalid coordinates (`0,0`, `-1,-1`, `1,1`) are excluded from the `vehicles` query and subscription unless the client passes `includeInvalidLocations: true`.
+
+**Architecture:** A new `InvalidLocationRegistry` Spring bean parses a configured list of invalid lat/lon pairs and answers `isInvalid(Location)`. `QueryFilter` gains an optional location-validity check that all vehicle read paths already funnel through (`Query.getVehicles` → `VehicleRepository.getVehicles(filter)`, and `Subscription.vehicles` → `VehicleUpdateRxPublisher`, whose `.filter(...)` stage sits after `startWith(initialdata)` and so covers both the initial snapshot and live updates). Storage, ingestion and enrichment are untouched.
+
+**Tech Stack:** Java (Spring Boot 3 / Spring GraphQL), Maven, JUnit 5, Mockito, AssertJ.
+
+**Spec:** `docs/superpowers/specs/2026-08-11-invalid-vehicle-locations-design.md`
+
+## Global Constraints
+
+- Package root is `org.entur.vehicles`. Source in `src/main/java`, tests in `src/test/java` mirroring the package.
+- Build/test command is Maven: `mvn test -Dtest=<ClassName>` for a single class, `mvn test` for the suite.
+- Default invalid coordinates, in `latitude/longitude` order: `0.0/0.0,-1.0/-1.0,1.0/1.0`.
+- Configuration property name: `vehicle.invalid.locations`.
+- GraphQL argument name and default: `includeInvalidLocations: Boolean = false`, on `Query.vehicles` and `Subscription.vehicles` only — never on `timetables` or `situations`.
+- **Trap:** `org.entur.vehicles.data.model.Location`'s constructor is `Location(double longitude, double latitude)` — **longitude first**. Its getters are `getLatitude()` / `getLongitude()` and return boxed `Double`.
+- Existing behaviour must not change when the new wiring is absent: a `QueryFilter` on which the new setter was never called (timetable filters, situation filters, existing tests) filters exactly as it does today.
+- Indentation in this codebase is 2 spaces in `data/`, `repository/` and `service/`; 4 spaces in `graphql/`. Match the file you are editing.
+
+---
+
+### Task 1: `InvalidLocationRegistry`
+
+The registry owns the definition of "invalid location": it parses the configured pairs once at construction and answers `isInvalid(Location)`. Nothing else in the codebase knows which coordinates are invalid.
+
+**Files:**
+- Create: `src/main/java/org/entur/vehicles/service/InvalidLocationRegistry.java`
+- Modify: `src/main/resources/application.properties` (append a new property)
+- Test: `src/test/java/org/entur/vehicles/service/InvalidLocationRegistryTest.java`
+
+**Interfaces:**
+- Consumes: `org.entur.vehicles.data.model.Location` (existing).
+- Produces:
+  - `public InvalidLocationRegistry(String invalidLocations)` — single constructor, annotated with `@Value("${vehicle.invalid.locations:0.0/0.0,-1.0/-1.0,1.0/1.0}")` on the parameter, so tests can construct it directly with a plain string.
+  - `public boolean isInvalid(Location location)` — `false` for `null` location or `null` coordinate components.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/test/java/org/entur/vehicles/service/InvalidLocationRegistryTest.java`:
+
+```java
+package org.entur.vehicles.service;
+
+import org.entur.vehicles.data.model.Location;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InvalidLocationRegistryTest {
+
+  private static final String DEFAULT_CONFIG = "0.0/0.0,-1.0/-1.0,1.0/1.0";
+
+  // NOTE: Location takes (longitude, latitude) - longitude first.
+  private static Location location(double latitude, double longitude) {
+    return new Location(longitude, latitude);
+  }
+
+  @Test
+  void theDefaultConfiguredCoordinatesAreInvalid() {
+    InvalidLocationRegistry registry = new InvalidLocationRegistry(DEFAULT_CONFIG);
+
+    assertThat(registry.isInvalid(location(0.0, 0.0))).isTrue();
+    assertThat(registry.isInvalid(location(-1.0, -1.0))).isTrue();
+    assertThat(registry.isInvalid(location(1.0, 1.0))).isTrue();
+  }
+
+  @Test
+  void aRealCoordinateIsValid() {
+    InvalidLocationRegistry registry = new InvalidLocationRegistry(DEFAULT_CONFIG);
+
+    // Oslo
+    assertThat(registry.isInvalid(location(59.911491, 10.757933))).isFalse();
+  }
+
+  @Test
+  void aCoordinateMatchingOnlyOneComponentIsValid() {
+    InvalidLocationRegistry registry = new InvalidLocationRegistry(DEFAULT_CONFIG);
+
+    assertThat(registry.isInvalid(location(0.0, 10.757933))).isFalse();
+    assertThat(registry.isInvalid(location(59.911491, 0.0))).isFalse();
+  }
+
+  @Test
+  void negativeZeroMatchesAConfiguredZero() {
+    InvalidLocationRegistry registry = new InvalidLocationRegistry(DEFAULT_CONFIG);
+
+    assertThat(registry.isInvalid(location(-0.0, -0.0))).isTrue();
+  }
+
+  @Test
+  void aNullLocationIsValid() {
+    InvalidLocationRegistry registry = new InvalidLocationRegistry(DEFAULT_CONFIG);
+
+    assertThat(registry.isInvalid(null)).isFalse();
+  }
+
+  @Test
+  void aLocationWithNullComponentsIsValid() {
+    InvalidLocationRegistry registry = new InvalidLocationRegistry(DEFAULT_CONFIG);
+
+    Location location = location(0.0, 0.0);
+    location.setLatitude(null);
+
+    assertThat(registry.isInvalid(location)).isFalse();
+  }
+
+  @Test
+  void aCustomConfigurationReplacesTheDefaults() {
+    InvalidLocationRegistry registry = new InvalidLocationRegistry("12.5/13.5");
+
+    assertThat(registry.isInvalid(location(12.5, 13.5))).isTrue();
+    assertThat(registry.isInvalid(location(0.0, 0.0))).isFalse();
+  }
+
+  @Test
+  void whitespaceAroundEntriesIsIgnored() {
+    InvalidLocationRegistry registry = new InvalidLocationRegistry("  0.0 / 0.0 ,  1.0/1.0  ");
+
+    assertThat(registry.isInvalid(location(0.0, 0.0))).isTrue();
+    assertThat(registry.isInvalid(location(1.0, 1.0))).isTrue();
+  }
+
+  @Test
+  void aMalformedEntryIsSkippedAndTheRestStillParsed() {
+    InvalidLocationRegistry registry = new InvalidLocationRegistry("0.0/0.0,not-a-coordinate,7.0/8.0/9.0,1.0/1.0");
+
+    assertThat(registry.isInvalid(location(0.0, 0.0))).isTrue();
+    assertThat(registry.isInvalid(location(1.0, 1.0))).isTrue();
+  }
+
+  @Test
+  void anEmptyConfigurationDisablesTheRegistry() {
+    InvalidLocationRegistry registry = new InvalidLocationRegistry("");
+
+    assertThat(registry.isInvalid(location(0.0, 0.0))).isFalse();
+  }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `mvn test -Dtest=InvalidLocationRegistryTest`
+Expected: FAIL — compilation error, `cannot find symbol: class InvalidLocationRegistry`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/main/java/org/entur/vehicles/service/InvalidLocationRegistry.java`:
+
+```java
+package org.entur.vehicles.service;
+
+import org.entur.vehicles.data.model.Location;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Coordinates that upstream data producers are known to report for vehicles whose real position
+ * is unknown - e.g. {@code 0,0}. Such vehicles are still stored and still queryable, but are
+ * excluded from responses unless the client explicitly asks for them.
+ * <p>
+ * The list is configuration rather than code so that a new variant of the same upstream bug can
+ * be handled by a config change and redeploy. Matching is exact: only the configured pairs are
+ * treated as invalid.
+ */
+@Component
+public class InvalidLocationRegistry {
+
+  private static final Logger LOG = LoggerFactory.getLogger(InvalidLocationRegistry.class);
+
+  private final Set<Coordinate> invalidCoordinates;
+
+  public InvalidLocationRegistry(
+      @Value("${vehicle.invalid.locations:0.0/0.0,-1.0/-1.0,1.0/1.0}") String invalidLocations
+  ) {
+    this.invalidCoordinates = parse(invalidLocations);
+    LOG.info("Treating {} coordinate(s) as invalid vehicle locations: {}",
+        invalidCoordinates.size(), invalidCoordinates);
+  }
+
+  public boolean isInvalid(Location location) {
+    if (location == null || location.getLatitude() == null || location.getLongitude() == null) {
+      return false;
+    }
+    return invalidCoordinates.contains(
+        new Coordinate(normalize(location.getLatitude()), normalize(location.getLongitude()))
+    );
+  }
+
+  private static Set<Coordinate> parse(String invalidLocations) {
+    Set<Coordinate> coordinates = new HashSet<>();
+    if (invalidLocations == null || invalidLocations.isBlank()) {
+      return coordinates;
+    }
+    for (String entry : invalidLocations.split(",")) {
+      String trimmed = entry.trim();
+      if (trimmed.isEmpty()) {
+        continue;
+      }
+      String[] parts = trimmed.split("/");
+      if (parts.length != 2) {
+        LOG.warn("Ignoring malformed entry '{}' in vehicle.invalid.locations - expected 'latitude/longitude'", trimmed);
+        continue;
+      }
+      try {
+        coordinates.add(new Coordinate(
+            normalize(Double.parseDouble(parts[0].trim())),
+            normalize(Double.parseDouble(parts[1].trim()))
+        ));
+      } catch (NumberFormatException e) {
+        LOG.warn("Ignoring entry '{}' in vehicle.invalid.locations - not a numeric coordinate pair", trimmed);
+      }
+    }
+    return coordinates;
+  }
+
+  /**
+   * {@code -0.0} and {@code 0.0} are distinct values to {@code Double.equals}, so a feed
+   * reporting {@code -0.0} would not match a configured {@code 0.0} without this.
+   */
+  private static double normalize(double value) {
+    return value == 0.0 ? 0.0 : value;
+  }
+
+  private record Coordinate(double latitude, double longitude) {
+  }
+}
+```
+
+- [ ] **Step 4: Add the property**
+
+Append to `src/main/resources/application.properties`, at the end of the file:
+
+```properties
+# Coordinates reported by upstream producers for vehicles whose real position is unknown.
+# Comma-separated latitude/longitude pairs, matched exactly. Vehicles at these coordinates are
+# still stored and still queryable, but are only returned when a client passes
+# includeInvalidLocations: true.
+vehicle.invalid.locations=0.0/0.0,-1.0/-1.0,1.0/1.0
+```
+
+The same values are the `@Value` default in the bean, so tests that boot a Spring context (which use `src/test/resources/application.properties`, where the property is not set) get the documented behaviour without further configuration.
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `mvn test -Dtest=InvalidLocationRegistryTest`
+Expected: PASS — 10 tests.
+
+- [ ] **Step 6: Run the existing Spring-context test to confirm the new bean wires**
+
+Run: `mvn test -Dtest=ApplicationGraphQlSchemaTests`
+Expected: PASS. This test boots a real Spring context, so it constructs the new `@Component` and would fail if the `@Value` placeholder could not be resolved.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/main/java/org/entur/vehicles/service/InvalidLocationRegistry.java \
+        src/test/java/org/entur/vehicles/service/InvalidLocationRegistryTest.java \
+        src/main/resources/application.properties
+git commit -m "Add InvalidLocationRegistry for known-invalid vehicle coordinates"
+```
+
+---
+
+### Task 2: Location-validity check in `QueryFilter`
+
+`QueryFilter.isMatch(VehicleUpdate)` is the single choke point for every vehicle response path, so the check goes there. The two existing constructors already take 14 and 16 arguments and are called from eight test sites, so the new state is supplied by a fluent setter instead of growing them.
+
+**Files:**
+- Modify: `src/main/java/org/entur/vehicles/data/QueryFilter.java`
+- Test: `src/test/java/org/entur/vehicles/data/QueryFilterTest.java` (append tests, leave existing ones untouched)
+
+**Interfaces:**
+- Consumes: `InvalidLocationRegistry.isInvalid(Location)` from Task 1.
+- Produces: `public QueryFilter withLocationValidity(InvalidLocationRegistry invalidLocations, boolean includeInvalidLocations)` — returns `this` so it can be chained onto construction. When never called, `isMatch` behaves exactly as before.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append these tests to `src/test/java/org/entur/vehicles/data/QueryFilterTest.java`, inside the existing `QueryFilterTest` class (before the final closing brace). Also add the imports `org.entur.vehicles.data.model.Location` and `org.entur.vehicles.service.InvalidLocationRegistry` to the file's import block:
+
+```java
+  private static QueryFilter emptyFilter() {
+    return new QueryFilter(
+            null,
+            MetricType.QUERY,
+            null, null, null, null, null, null,
+            null, null,
+            null, null, null, null
+    );
+  }
+
+  private static VehicleUpdate vehicleAt(double latitude, double longitude) {
+    VehicleUpdate update = new VehicleUpdate();
+    // NOTE: Location takes (longitude, latitude) - longitude first.
+    update.setLocation(new Location(longitude, latitude));
+    return update;
+  }
+
+  @Test
+  void testInvalidLocationExcludedByDefault() {
+    InvalidLocationRegistry registry = new InvalidLocationRegistry("0.0/0.0,-1.0/-1.0,1.0/1.0");
+    QueryFilter filter = emptyFilter().withLocationValidity(registry, false);
+
+    assertFalse(filter.isMatch(vehicleAt(0.0, 0.0)));
+    assertFalse(filter.isMatch(vehicleAt(-1.0, -1.0)));
+    assertFalse(filter.isMatch(vehicleAt(1.0, 1.0)));
+  }
+
+  @Test
+  void testValidLocationMatchesRegardlessOfFlag() {
+    InvalidLocationRegistry registry = new InvalidLocationRegistry("0.0/0.0,-1.0/-1.0,1.0/1.0");
+
+    assertTrue(emptyFilter().withLocationValidity(registry, false).isMatch(vehicleAt(59.911491, 10.757933)));
+    assertTrue(emptyFilter().withLocationValidity(registry, true).isMatch(vehicleAt(59.911491, 10.757933)));
+  }
+
+  @Test
+  void testInvalidLocationIncludedWhenRequested() {
+    InvalidLocationRegistry registry = new InvalidLocationRegistry("0.0/0.0,-1.0/-1.0,1.0/1.0");
+    QueryFilter filter = emptyFilter().withLocationValidity(registry, true);
+
+    assertTrue(filter.isMatch(vehicleAt(0.0, 0.0)));
+  }
+
+  @Test
+  void testFilterWithoutLocationValidityIsUnchanged() {
+    // Timetable and situation filters - and every pre-existing test - never call
+    // withLocationValidity, and must keep matching invalid locations.
+    assertTrue(emptyFilter().isMatch(vehicleAt(0.0, 0.0)));
+  }
+
+  @Test
+  void testNullRegistryDisablesTheCheck() {
+    assertTrue(emptyFilter().withLocationValidity(null, false).isMatch(vehicleAt(0.0, 0.0)));
+  }
+
+  @Test
+  void testInvalidLocationExcludedEvenWhenOtherCriteriaMatch() {
+    InvalidLocationRegistry registry = new InvalidLocationRegistry("0.0/0.0");
+    QueryFilter filter = new QueryFilter(
+            null,
+            MetricType.QUERY,
+            null, null, null, null, null, null,
+            "TST:Line:123",
+            null,
+            null, null, null, null
+    ).withLocationValidity(registry, false);
+
+    VehicleUpdate update = vehicleAt(0.0, 0.0);
+    update.setLine(new Line("TST:Line:123", "A - B"));
+
+    assertFalse(filter.isMatch(update));
+  }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `mvn test -Dtest=QueryFilterTest`
+Expected: FAIL — compilation error, `cannot find symbol: method withLocationValidity(...)`.
+
+- [ ] **Step 3: Implement the check**
+
+In `src/main/java/org/entur/vehicles/data/QueryFilter.java`:
+
+Add the import alongside the existing `org.entur.vehicles.service.OperatorService` import:
+
+```java
+import org.entur.vehicles.service.InvalidLocationRegistry;
+```
+
+Add two fields after the existing `private MetricType metricType = UNDEFINED;` declaration:
+
+```java
+  private InvalidLocationRegistry invalidLocations;
+  private boolean includeInvalidLocations;
+```
+
+Add the setter directly after the constructors, above `getBufferSize()`:
+
+```java
+  /**
+   * Enables filtering of vehicles reported at known-invalid coordinates. Only the vehicle query
+   * and subscription call this; filters that never do - timetables and situations - keep matching
+   * every location.
+   */
+  public QueryFilter withLocationValidity(InvalidLocationRegistry invalidLocations, boolean includeInvalidLocations) {
+    this.invalidLocations = invalidLocations;
+    this.includeInvalidLocations = includeInvalidLocations;
+    return this;
+  }
+```
+
+In `isMatch(VehicleUpdate vehicleUpdate)`, insert this block immediately after the `boundingBox` block and before the `serviceJourneys` block:
+
+```java
+    if (isCompleteMatch && !includeInvalidLocations && invalidLocations != null) {
+      isCompleteMatch = !invalidLocations.isInvalid(vehicleUpdate.getLocation());
+    }
+```
+
+Add one line to `toString()`, after the `.add("boundingBox=" + boundingBox)` line, so the debug logging in `Query` and `Subscription` shows the flag:
+
+```java
+        .add("includeInvalidLocations=" + includeInvalidLocations)
+```
+
+Do not touch `isMatch(EstimatedTimetableUpdate)`.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `mvn test -Dtest=QueryFilterTest`
+Expected: PASS — the five pre-existing tests plus the six new ones.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/java/org/entur/vehicles/data/QueryFilter.java \
+        src/test/java/org/entur/vehicles/data/QueryFilterTest.java
+git commit -m "Filter vehicles at invalid locations in QueryFilter"
+```
+
+---
+
+### Task 3: Expose `includeInvalidLocations` in the GraphQL API
+
+Wires the schema argument through both resolvers. `Query` and `Subscription` each gain an `InvalidLocationRegistry` constructor dependency; four existing test call sites construct `Query` directly and must be updated in the same commit or the build will not compile.
+
+**Files:**
+- Modify: `src/main/resources/graphql/vehicle-updates.graphqls` (`Query.vehicles` around line 16-32, `Subscription.vehicles` around line 77-98)
+- Modify: `src/main/java/org/entur/vehicles/graphql/Query.java`
+- Modify: `src/main/java/org/entur/vehicles/graphql/Subscription.java`
+- Modify: `src/test/java/org/entur/vehicles/graphql/SituationGraphQLTests.java:90,270` and `src/test/java/org/entur/vehicles/graphql/TimetableGraphQLTests.java:54` (constructor call sites only)
+- Test: `src/test/java/org/entur/vehicles/graphql/VehicleGraphQLTests.java`
+
+**Interfaces:**
+- Consumes: `InvalidLocationRegistry` (Task 1), `QueryFilter.withLocationValidity(...)` (Task 2).
+- Produces:
+  - `Query(VehicleRepository, TimetableRepository, SituationRepository, NSRService, PrometheusMetricsService, InvalidLocationRegistry)` — registry appended as the last parameter.
+  - `Subscription(VehicleUpdateRxPublisher, EstimatedTimetableUpdateRxPublisher, SituationUpdateRxPublisher, NSRService, PrometheusMetricsService, InvalidLocationRegistry)` — registry appended as the last parameter.
+  - `Query.getVehicles(...)` gains a final `@Argument Boolean includeInvalidLocations` parameter, after `maxDataAge`.
+  - `Subscription.vehicles(...)` gains `@Argument Boolean includeInvalidLocations` after `maxDataAge` and **before** `bufferSize`/`bufferTime`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/test/java/org/entur/vehicles/graphql/VehicleGraphQLTests.java`. Add the imports `java.util.Collection`, `org.entur.vehicles.data.VehicleUpdate` and `org.entur.vehicles.service.InvalidLocationRegistry`, then append these members inside the existing class:
+
+```java
+    private VehicleActivityRecord createVehicleActivity(String codespace, String vehicleRef, String lineRef,
+                                                        double latitude, double longitude) {
+        VehicleActivityRecord record = new VehicleActivityRecord();
+        record.setRecordedAtTime(ZonedDateTime.now().toString());
+        record.setValidUntilTime(ZonedDateTime.now().plusMinutes(10).toString());
+
+        MonitoredVehicleJourneyRecord journey = new MonitoredVehicleJourneyRecord();
+        journey.setLineRef(lineRef);
+        journey.setVehicleRef(vehicleRef);
+        journey.setMonitored(true);
+        journey.setDataSource(codespace);
+
+        LocationRecord location = new LocationRecord();
+        location.setLatitude(latitude);
+        location.setLongitude(longitude);
+        journey.setVehicleLocation(location);
+
+        record.setMonitoredVehicleJourney(journey);
+        return record;
+    }
+
+    private Collection<VehicleUpdate> queryVehicles(String codespaceId, Boolean includeInvalidLocations) {
+        return queryService.getVehicles(
+                null,   // serviceJourneyId
+                null,   // date
+                null,   // serviceJourneyIdAndDates
+                null,   // datedServiceJourneyId
+                null,   // datedServiceJourneyIds
+                null,   // operatorRef
+                codespaceId,
+                null,   // mode
+                null,   // vehicleId
+                null,   // vehicleIds
+                null,   // lineRef
+                null,   // lineName
+                null,   // monitored
+                null,   // boundingBox
+                null,   // maxDataAge
+                includeInvalidLocations
+        );
+    }
+
+    @Test
+    public void testInvalidLocationsAreExcludedUnlessRequested() {
+        repository.addAll(List.of(
+                createVehicleActivity("INV", "INV:Vehicle:valid", "INV:Line:1", 59.911491, 10.757933),
+                createVehicleActivity("INV", "INV:Vehicle:invalid", "INV:Line:1", 0.0, 0.0)
+        ));
+
+        // Argument omitted by the client - GraphQL applies the schema default of false
+        Collection<VehicleUpdate> defaultResult = queryVehicles("INV", null);
+        assertEquals(1, defaultResult.size());
+        assertEquals("INV:Vehicle:valid", defaultResult.iterator().next().getVehicleId());
+
+        Collection<VehicleUpdate> explicitlyExcluded = queryVehicles("INV", false);
+        assertEquals(1, explicitlyExcluded.size());
+
+        Collection<VehicleUpdate> included = queryVehicles("INV", true);
+        assertEquals(2, included.size());
+        assertTrue(included.stream().anyMatch(v -> "INV:Vehicle:invalid".equals(v.getVehicleId())));
+    }
+```
+
+Update the `Query` construction in `initData()` (currently line 54) to pass a registry:
+
+```java
+        queryService = new Query(repository, null, null, new NSRService(false, null), metricsService,
+                new InvalidLocationRegistry("0.0/0.0,-1.0/-1.0,1.0/1.0"));
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `mvn test -Dtest=VehicleGraphQLTests`
+Expected: FAIL — compilation error, `constructor Query ... cannot be applied to given types` and `method getVehicles ... cannot be applied to given types`.
+
+- [ ] **Step 3: Update the schema**
+
+In `src/main/resources/graphql/vehicle-updates.graphqls`, in the **`Query.vehicles`** field, replace the final argument line:
+
+```graphql
+        maxDataAge: Duration,) : [VehicleUpdate]
+```
+
+with:
+
+```graphql
+        maxDataAge: Duration,
+        # Include vehicles whose reported coordinates are known to be invalid (e.g. 0,0).
+        # Such vehicles are excluded by default.
+        includeInvalidLocations: Boolean = false) : [VehicleUpdate]
+```
+
+In the **`Subscription.vehicles`** field, insert the same argument after the `maxDataAge: Duration,` line and before the `bufferSize` comment:
+
+```graphql
+                   # Include vehicles whose reported coordinates are known to be invalid (e.g. 0,0).
+                   # Such vehicles are excluded by default.
+                   includeInvalidLocations: Boolean = false
+```
+
+Leave `timetables` and `situations` untouched in both `Query` and `Subscription`.
+
+- [ ] **Step 4: Wire `Query`**
+
+In `src/main/java/org/entur/vehicles/graphql/Query.java`:
+
+Add the import next to the existing `org.entur.vehicles.service.NSRService` import:
+
+```java
+import org.entur.vehicles.service.InvalidLocationRegistry;
+```
+
+Add the field after `private final NSRService nsrService;`:
+
+```java
+    private final InvalidLocationRegistry invalidLocationRegistry;
+```
+
+Extend the constructor:
+
+```java
+    public Query(VehicleRepository vehicleRepository,
+                 TimetableRepository timetableRepository,
+                 SituationRepository situationRepository,
+                 NSRService nsrService,
+                 PrometheusMetricsService metricsService,
+                 InvalidLocationRegistry invalidLocationRegistry) {
+        this.vehicleRepository = vehicleRepository;
+        this.timetableRepository = timetableRepository;
+        this.situationRepository = situationRepository;
+        this.nsrService = nsrService;
+        this.metricsService = metricsService;
+        this.invalidLocationRegistry = invalidLocationRegistry;
+    }
+```
+
+Add the argument to `getVehicles`, after `@Argument Duration maxDataAge`:
+
+```java
+                                          @Argument Duration maxDataAge,
+                                          @Argument Boolean includeInvalidLocations) {
+```
+
+And chain the setter onto the filter construction — the existing statement ends with `);` on the line after `maxDataAge`:
+
+```java
+        final QueryFilter filter = new QueryFilter(
+                metricsService,
+                MetricType.QUERY,
+                serviceJourneyIdAndDates,
+                datedServiceJourneyIds,
+                operatorRef,
+                codespaceId,
+                mode,
+                vehicleIds,
+                lineRef,
+                lineName,
+                monitored,
+                false, // cancellation is not used in vehicle queries
+                boundingBox,
+                maxDataAge
+        ).withLocationValidity(invalidLocationRegistry, Boolean.TRUE.equals(includeInvalidLocations));
+```
+
+`Boolean.TRUE.equals(...)` treats a client-supplied explicit `null` as `false`, matching the schema default.
+
+- [ ] **Step 5: Wire `Subscription`**
+
+In `src/main/java/org/entur/vehicles/graphql/Subscription.java`, make the same three changes:
+
+Import:
+
+```java
+import org.entur.vehicles.service.InvalidLocationRegistry;
+```
+
+Field after `private final NSRService nsrService;`:
+
+```java
+    private final InvalidLocationRegistry invalidLocationRegistry;
+```
+
+Constructor:
+
+```java
+    Subscription(VehicleUpdateRxPublisher vehicleUpdater,
+                 EstimatedTimetableUpdateRxPublisher timetableUpdater,
+                 SituationUpdateRxPublisher situationUpdater,
+                 NSRService nsrService,
+                 PrometheusMetricsService metricsService,
+                 InvalidLocationRegistry invalidLocationRegistry) {
+        this.vehicleUpdater = vehicleUpdater;
+        this.timetableUpdater = timetableUpdater;
+        this.situationUpdater = situationUpdater;
+        this.nsrService = nsrService;
+        this.metricsService = metricsService;
+        this.invalidLocationRegistry = invalidLocationRegistry;
+    }
+```
+
+Argument on `vehicles(...)`, after `@Argument Duration maxDataAge,` and before `@Argument Integer bufferSize`:
+
+```java
+                                            @Argument Boolean includeInvalidLocations,
+```
+
+Filter construction in `vehicles(...)` — the one built with `MetricType.SUBSCRIPTION`, `bufferSize` and `bufferTime`:
+
+```java
+        final QueryFilter filter = new QueryFilter(
+                metricsService,
+                MetricType.SUBSCRIPTION,
+                serviceJourneyIdAndDates,
+                datedServiceJourneyIds,
+                operatorRef,
+                codespaceId,
+                mode,
+                vehicleIds,
+                lineRef,
+                lineName,
+                monitored,
+                null, // cancellation is not used in vehicle updates
+                boundingBox,
+                maxDataAge,
+                bufferSize,
+                bufferTime
+        ).withLocationValidity(invalidLocationRegistry, Boolean.TRUE.equals(includeInvalidLocations));
+```
+
+Leave the `timetables` and `situations` subscription methods unchanged.
+
+- [ ] **Step 6: Update the other `Query` construction sites**
+
+These three call sites do not query vehicles, so they pass `null` for the registry — with a `null` registry the location check is skipped, exactly as before this change:
+
+`src/test/java/org/entur/vehicles/graphql/SituationGraphQLTests.java:90`:
+
+```java
+        queryService = new Query(null, null, repository, new NSRService(false, null), metricsService, null);
+```
+
+`src/test/java/org/entur/vehicles/graphql/SituationGraphQLTests.java:270`:
+
+```java
+        Query ancestorQueryService = new Query(null, null, repository, ancestorAwareNsrService, metricsService, null);
+```
+
+`src/test/java/org/entur/vehicles/graphql/TimetableGraphQLTests.java:54`:
+
+```java
+        queryService = new Query(null, repository, null, new NSRService(false, null), metricsService, null);
+```
+
+- [ ] **Step 7: Run the vehicle tests to verify they pass**
+
+Run: `mvn test -Dtest=VehicleGraphQLTests`
+Expected: PASS — `testQueries` and `testInvalidLocationsAreExcludedUnlessRequested`.
+
+- [ ] **Step 8: Run the full suite**
+
+Run: `mvn test`
+Expected: PASS, all tests. `ApplicationGraphQlSchemaTests` boots a real Spring context and executes GraphQL documents, so it verifies the schema still parses and that both resolvers still map to their fields with the new argument in place.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/main/resources/graphql/vehicle-updates.graphqls \
+        src/main/java/org/entur/vehicles/graphql/Query.java \
+        src/main/java/org/entur/vehicles/graphql/Subscription.java \
+        src/test/java/org/entur/vehicles/graphql/VehicleGraphQLTests.java \
+        src/test/java/org/entur/vehicles/graphql/SituationGraphQLTests.java \
+        src/test/java/org/entur/vehicles/graphql/TimetableGraphQLTests.java
+git commit -m "Add includeInvalidLocations argument to vehicles query and subscription"
+```
+
+---
+
+## Verification
+
+After Task 3, confirm against the spec's behaviour table:
+
+- `mvn test` passes in full.
+- `git diff main --stat` shows changes only in: the new registry and its test, `QueryFilter` and its test, the schema, the two resolvers, and the four test call sites, plus `application.properties`.
+- No change to `VehicleRepository`, `AutoPurgingVehicleMap`, `VehicleUpdateRxPublisher`, `TimetableRepository` or `SituationRepository` — invalid-location vehicles are still ingested, stored, enriched and purged exactly as before.

--- a/docs/superpowers/specs/2026-08-11-invalid-vehicle-locations-design.md
+++ b/docs/superpowers/specs/2026-08-11-invalid-vehicle-locations-design.md
@@ -1,0 +1,175 @@
+# Opt-in filtering of vehicles with invalid locations
+
+Date: 2026-08-11
+
+## Problem
+
+The API returns vehicles whose reported coordinates are obviously bogus — latitude/longitude
+of `0, 0`, `-1, -1` and `1, 1`. These come from upstream data producers and land in the
+repository because `VehicleRepository.add()` only requires a non-null location. Users see
+vehicles floating off the coast of Africa in map clients.
+
+The data must still be stored and still be retrievable, but only when a client explicitly
+asks for it.
+
+## Solution overview
+
+Add an optional `includeInvalidLocations: Boolean = false` argument to the `vehicles` query
+and the `vehicles` subscription. Vehicles at a known-invalid coordinate are filtered out of
+the response unless the client passes `true`. Ingestion, storage, enrichment and purging are
+unchanged.
+
+## Design
+
+### 1. `InvalidLocationRegistry`
+
+New Spring component, `org.entur.vehicles.service.InvalidLocationRegistry`.
+
+Holds the set of coordinates considered invalid, read from configuration at construction:
+
+```properties
+# application.properties
+# Comma-separated lat/lon pairs that are treated as invalid vehicle locations
+vehicle.invalid.locations=0.0/0.0,-1.0/-1.0,1.0/1.0
+```
+
+- The property value is parsed into a `Set<Coordinate>`, where `Coordinate` is a private
+  nested `record Coordinate(double latitude, double longitude)` on the registry — it is an
+  implementation detail and is not exposed to callers.
+- The order within a pair is `latitude/longitude`.
+- Whitespace around entries and around the separator is trimmed.
+- A malformed entry (wrong number of components, unparseable number) is logged at `WARN`
+  and skipped. Startup does not fail.
+- An empty or blank property value yields an empty set, which disables the filtering
+  entirely.
+
+Public API:
+
+```java
+boolean isInvalid(Location location)
+```
+
+- Returns `false` for a `null` location. Vehicles without a location are never stored, so
+  this case does not arise in practice; returning `false` keeps the method total.
+- Matching is exact double equality against the configured set. The three default values
+  (`0.0`, `1.0`, `-1.0`) are exactly representable in binary floating point, so no epsilon
+  is required.
+
+Deliberate trade-off: only the exact configured coordinates are treated as invalid. A new
+variant of the same upstream bug — say `0.0, 0.5` — is not caught until the property is
+updated. Because the list is configuration rather than code, that is a config change and
+redeploy, not a code change and release.
+
+### 2. Filter application point
+
+Every path that returns vehicle data passes through `QueryFilter.isMatch(VehicleUpdate)`:
+
+- `Query.getVehicles` → `VehicleRepository.getVehicles(filter)` → `filter::isMatch`
+- `Subscription.vehicles` → `VehicleUpdateRxPublisher.getPublisher(filter, uuid)`, where the
+  initial snapshot is emitted via `startWith(initialdata)` *before* the
+  `.filter(vehicleUpdate -> template == null || template.isMatch(vehicleUpdate))` stage, so
+  both the snapshot and the live updates are filtered.
+
+A single check in `QueryFilter.isMatch(VehicleUpdate)` therefore covers queries,
+subscription snapshots and subscription updates.
+
+`QueryFilter` gains two fields:
+
+```java
+private InvalidLocationRegistry invalidLocations;
+private boolean includeInvalidLocations;
+```
+
+and the check, placed immediately after the bounding-box check so it exits early:
+
+```java
+if (isCompleteMatch && !includeInvalidLocations && invalidLocations != null) {
+  isCompleteMatch = !invalidLocations.isInvalid(vehicleUpdate.getLocation());
+}
+```
+
+The two existing `QueryFilter` constructors already take 14 and 16 arguments and are called
+from eight test sites, so the new state is supplied by a fluent setter rather than by growing
+them:
+
+```java
+public QueryFilter withLocationValidity(InvalidLocationRegistry registry, boolean includeInvalidLocations)
+```
+
+It returns `this` so call sites can chain it onto construction. When it is not called — the
+timetable and situation filters, and existing tests — `invalidLocations` stays `null` and
+behaviour is unchanged.
+
+`isMatch(EstimatedTimetableUpdate)` is not touched.
+
+### 3. Schema and resolvers
+
+`src/main/resources/graphql/vehicle-updates.graphqls`, on `Query.vehicles` and
+`Subscription.vehicles` only:
+
+```graphql
+# Include vehicles whose reported coordinates are known to be invalid (e.g. 0,0).
+# Excluded by default.
+includeInvalidLocations: Boolean = false
+```
+
+`timetables` and `situations` are not changed.
+
+`Query` and `Subscription` each:
+
+- take `InvalidLocationRegistry` as a constructor dependency,
+- accept `@Argument Boolean includeInvalidLocations` on their `vehicles` method,
+- call `.withLocationValidity(invalidLocationRegistry, Boolean.TRUE.equals(includeInvalidLocations))`
+  on the filter they build.
+
+`Boolean.TRUE.equals(...)` treats an explicit `null` (a client passing `null` rather than
+omitting the argument) as `false`, matching the schema default.
+
+### 4. Behaviour summary
+
+| Request | Result |
+|---|---|
+| `vehicles(...)` — argument omitted | Vehicles at configured invalid coordinates are excluded |
+| `vehicles(includeInvalidLocations: false)` | Same as above |
+| `vehicles(includeInvalidLocations: true)` | All vehicles, exactly as today |
+| `subscription { vehicles(...) }` | Applies to initial snapshot and to live updates alike |
+| `timetables`, `situations` | Unchanged |
+
+Storage, enrichment and purge behaviour are unchanged in all cases. Prometheus
+`markFilterMatch` continues to fire only for vehicles that match the whole filter, so
+excluded invalid-location vehicles are simply not counted.
+
+## Testing
+
+**`InvalidLocationRegistryTest`**
+
+- Default property value yields the three documented coordinates.
+- A custom property value is parsed, including surrounding whitespace.
+- A malformed entry is skipped and the remaining valid entries are still parsed.
+- An empty property value yields an empty set and `isInvalid` then returns `false` for
+  `0, 0`.
+- `isInvalid` returns `true` for each of `(0,0)`, `(-1,-1)`, `(1,1)`; `false` for a valid
+  Oslo coordinate; `false` for `null`.
+
+**`QueryFilterTest`**
+
+- A vehicle at `(0,0)` does not match a filter configured with the registry and
+  `includeInvalidLocations = false`.
+- The same vehicle matches when `includeInvalidLocations = true`.
+- A vehicle at a valid coordinate matches in both cases.
+- A filter on which `withLocationValidity` was never called matches the `(0,0)` vehicle,
+  confirming the unchanged default for timetable and situation filters.
+
+**`VehicleGraphQLTests`**
+
+- Repository seeded with one valid vehicle and one at `(0,0)`; `Query.getVehicles` with the
+  argument omitted returns one vehicle, with `includeInvalidLocations = true` returns two.
+
+## Out of scope
+
+- Rejecting or dropping invalid-location vehicles at ingestion time. The data must stay
+  queryable.
+- Heuristic validity rules (near-origin boxes, geographic sanity boxes). Rejected in favour
+  of an explicit configured list.
+- Any change to `timetables` or `situations`.
+- Stop-point coordinates from `NSRService`.

--- a/docs/superpowers/specs/2026-08-11-invalid-vehicle-locations-design.md
+++ b/docs/superpowers/specs/2026-08-11-invalid-vehicle-locations-design.md
@@ -53,7 +53,8 @@ boolean isInvalid(Location location)
   this case does not arise in practice; returning `false` keeps the method total.
 - Matching is exact double equality against the configured set. The three default values
   (`0.0`, `1.0`, `-1.0`) are exactly representable in binary floating point, so no epsilon
-  is required.
+  is required. The single exception is signed zero: `-0.0` is normalised to `0.0` on both
+  sides of the comparison, so a feed reporting `-0.0` still matches a configured `0.0`.
 
 Deliberate trade-off: only the exact configured coordinates are treated as invalid. A new
 variant of the same upstream bug — say `0.0, 0.5` — is not caught until the property is

--- a/helm/vehicle-positions-2/templates/configmap.yaml
+++ b/helm/vehicle-positions-2/templates/configmap.yaml
@@ -39,6 +39,9 @@ data:
       vehicle.line.lookup.enabled=true
       vehicle.operator.lookup.enabled=true
 
+      # Coordinates treated as known-invalid vehicle locations and excluded from `vehicles` responses by default.
+      vehicle.invalid.locations=0.0/0.0,-1.0/-1.0,1.0/1.0
+
       vehicle.serviceJourney.concurrent.requests={{ .Values.configMap.journeyplanner.servicejourney.threadpoolsize }}
       vehicle.serviceJourney.concurrent.sleeptime={{ .Values.configMap.journeyplanner.servicejourney.sleeptime }}
       vehicle.line.concurrent.requests={{ .Values.configMap.journeyplanner.line.threadpoolsize }}

--- a/src/main/java/org/entur/vehicles/data/QueryFilter.java
+++ b/src/main/java/org/entur/vehicles/data/QueryFilter.java
@@ -9,6 +9,7 @@ import org.entur.vehicles.data.model.ObjectRef;
 import org.entur.vehicles.data.model.ServiceJourney;
 import org.entur.vehicles.data.model.ServiceJourneyIdAndDate;
 import org.entur.vehicles.metrics.PrometheusMetricsService;
+import org.entur.vehicles.service.InvalidLocationRegistry;
 import org.entur.vehicles.service.OperatorService;
 import org.springframework.graphql.data.method.annotation.SchemaMapping;
 
@@ -36,6 +37,9 @@ public class QueryFilter extends AbstractUpdate {
   private ZonedDateTime maxDataAge;
 
   private MetricType metricType = UNDEFINED;
+
+  private InvalidLocationRegistry invalidLocations;
+  private boolean includeInvalidLocations;
 
   public QueryFilter(
           PrometheusMetricsService metricsService, MetricType metricType,
@@ -103,6 +107,17 @@ public class QueryFilter extends AbstractUpdate {
     }
   }
 
+  /**
+   * Enables filtering of vehicles reported at known-invalid coordinates. Only the vehicle query
+   * and subscription call this; filters that never do - timetables and situations - keep matching
+   * every location.
+   */
+  public QueryFilter withLocationValidity(InvalidLocationRegistry invalidLocations, boolean includeInvalidLocations) {
+    this.invalidLocations = invalidLocations;
+    this.includeInvalidLocations = includeInvalidLocations;
+    return this;
+  }
+
   public int getBufferSize() {
     return bufferSize;
   }
@@ -117,6 +132,9 @@ public class QueryFilter extends AbstractUpdate {
 
     if (boundingBox != null) {
       isCompleteMatch = boundingBox.contains(vehicleUpdate.getLocation());
+    }
+    if (isCompleteMatch && !includeInvalidLocations && invalidLocations != null) {
+      isCompleteMatch = !invalidLocations.isInvalid(vehicleUpdate.getLocation());
     }
     if (isCompleteMatch && serviceJourneys != null) {
       if (vehicleUpdate.getDatedServiceJourney() == null) {
@@ -287,6 +305,7 @@ public class QueryFilter extends AbstractUpdate {
         .add("serviceJourneyIds='" + serviceJourneys + "'")
         .add("vehicleIds='" + vehicleIds + "'")
         .add("boundingBox=" + boundingBox)
+        .add("includeInvalidLocations=" + includeInvalidLocations)
         .add("mode=" + mode)
         .add("bufferSize=" + bufferSize)
         .add("bufferTime=" + bufferTimeMillis)

--- a/src/main/java/org/entur/vehicles/graphql/Query.java
+++ b/src/main/java/org/entur/vehicles/graphql/Query.java
@@ -18,6 +18,7 @@ import org.entur.vehicles.metrics.PrometheusMetricsService;
 import org.entur.vehicles.repository.SituationRepository;
 import org.entur.vehicles.repository.TimetableRepository;
 import org.entur.vehicles.repository.VehicleRepository;
+import org.entur.vehicles.service.InvalidLocationRegistry;
 import org.entur.vehicles.service.NSRService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,6 +39,7 @@ class Query {
     private final TimetableRepository timetableRepository;
     private final SituationRepository situationRepository;
     private final NSRService nsrService;
+    private final InvalidLocationRegistry invalidLocationRegistry;
 
     PrometheusMetricsService metricsService;
 
@@ -45,12 +47,14 @@ class Query {
                  TimetableRepository timetableRepository,
                  SituationRepository situationRepository,
                  NSRService nsrService,
-                 PrometheusMetricsService metricsService) {
+                 PrometheusMetricsService metricsService,
+                 InvalidLocationRegistry invalidLocationRegistry) {
         this.vehicleRepository = vehicleRepository;
         this.timetableRepository = timetableRepository;
         this.situationRepository = situationRepository;
         this.nsrService = nsrService;
         this.metricsService = metricsService;
+        this.invalidLocationRegistry = invalidLocationRegistry;
     }
 
 
@@ -103,7 +107,8 @@ class Query {
                                           @Argument String lineName,
                                           @Argument Boolean monitored,
                                           @Argument BoundingBox boundingBox,
-                                          @Argument Duration maxDataAge) {
+                                          @Argument Duration maxDataAge,
+                                          @Argument Boolean includeInvalidLocations) {
 
         if (vehicleId != null) {
             if (vehicleIds == null) {
@@ -143,7 +148,7 @@ class Query {
                 false, // cancellation is not used in vehicle queries
                 boundingBox,
                 maxDataAge
-        );
+        ).withLocationValidity(invalidLocationRegistry, Boolean.TRUE.equals(includeInvalidLocations));
         LOG.debug("Requesting vehicles with filter: {}", filter);
         final long start = System.currentTimeMillis();
         final Collection<VehicleUpdate> vehicles = vehicleRepository.getVehicles(filter);

--- a/src/main/java/org/entur/vehicles/graphql/Subscription.java
+++ b/src/main/java/org/entur/vehicles/graphql/Subscription.java
@@ -14,6 +14,7 @@ import org.entur.vehicles.graphql.publishers.EstimatedTimetableUpdateRxPublisher
 import org.entur.vehicles.graphql.publishers.SituationUpdateRxPublisher;
 import org.entur.vehicles.graphql.publishers.VehicleUpdateRxPublisher;
 import org.entur.vehicles.metrics.PrometheusMetricsService;
+import org.entur.vehicles.service.InvalidLocationRegistry;
 import org.entur.vehicles.service.NSRService;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
@@ -36,6 +37,7 @@ class Subscription {
     private final EstimatedTimetableUpdateRxPublisher timetableUpdater;
     private final SituationUpdateRxPublisher situationUpdater;
     private final NSRService nsrService;
+    private final InvalidLocationRegistry invalidLocationRegistry;
 
     PrometheusMetricsService metricsService;
 
@@ -43,12 +45,14 @@ class Subscription {
                  EstimatedTimetableUpdateRxPublisher timetableUpdater,
                  SituationUpdateRxPublisher situationUpdater,
                  NSRService nsrService,
-                 PrometheusMetricsService metricsService) {
+                 PrometheusMetricsService metricsService,
+                 InvalidLocationRegistry invalidLocationRegistry) {
         this.vehicleUpdater = vehicleUpdater;
         this.timetableUpdater = timetableUpdater;
         this.situationUpdater = situationUpdater;
         this.nsrService = nsrService;
         this.metricsService = metricsService;
+        this.invalidLocationRegistry = invalidLocationRegistry;
     }
 
     @SubscriptionMapping
@@ -67,6 +71,7 @@ class Subscription {
                                             @Argument Boolean monitored,
                                             @Argument BoundingBox boundingBox,
                                             @Argument Duration maxDataAge,
+                                            @Argument Boolean includeInvalidLocations,
                                             @Argument Integer bufferSize,
                                             @Argument Integer bufferTime) {
         final String uuid = UUID.randomUUID().toString();
@@ -110,7 +115,7 @@ class Subscription {
                 maxDataAge,
                 bufferSize,
                 bufferTime
-        );
+        ).withLocationValidity(invalidLocationRegistry, Boolean.TRUE.equals(includeInvalidLocations));
         LOG.debug("Creating new subscription with filter: {}", filter);
         return vehicleUpdater.getPublisher(filter, uuid);
     }

--- a/src/main/java/org/entur/vehicles/service/InvalidLocationRegistry.java
+++ b/src/main/java/org/entur/vehicles/service/InvalidLocationRegistry.java
@@ -1,0 +1,82 @@
+package org.entur.vehicles.service;
+
+import org.entur.vehicles.data.model.Location;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Coordinates that upstream data producers are known to report for vehicles whose real position
+ * is unknown - e.g. {@code 0,0}. Such vehicles are still stored and still queryable, but are
+ * excluded from responses unless the client explicitly asks for them.
+ * <p>
+ * The list is configuration rather than code so that a new variant of the same upstream bug can
+ * be handled by a config change and redeploy. Matching is exact: only the configured pairs are
+ * treated as invalid.
+ */
+@Component
+public class InvalidLocationRegistry {
+
+  private static final Logger LOG = LoggerFactory.getLogger(InvalidLocationRegistry.class);
+
+  private final Set<Coordinate> invalidCoordinates;
+
+  public InvalidLocationRegistry(
+      @Value("${vehicle.invalid.locations:0.0/0.0,-1.0/-1.0,1.0/1.0}") String invalidLocations
+  ) {
+    this.invalidCoordinates = parse(invalidLocations);
+    LOG.info("Treating {} coordinate(s) as invalid vehicle locations: {}",
+        invalidCoordinates.size(), invalidCoordinates);
+  }
+
+  public boolean isInvalid(Location location) {
+    if (location == null || location.getLatitude() == null || location.getLongitude() == null) {
+      return false;
+    }
+    return invalidCoordinates.contains(
+        new Coordinate(normalize(location.getLatitude()), normalize(location.getLongitude()))
+    );
+  }
+
+  private static Set<Coordinate> parse(String invalidLocations) {
+    Set<Coordinate> coordinates = new HashSet<>();
+    if (invalidLocations == null || invalidLocations.isBlank()) {
+      return coordinates;
+    }
+    for (String entry : invalidLocations.split(",")) {
+      String trimmed = entry.trim();
+      if (trimmed.isEmpty()) {
+        continue;
+      }
+      String[] parts = trimmed.split("/");
+      if (parts.length != 2) {
+        LOG.warn("Ignoring malformed entry '{}' in vehicle.invalid.locations - expected 'latitude/longitude'", trimmed);
+        continue;
+      }
+      try {
+        coordinates.add(new Coordinate(
+            normalize(Double.parseDouble(parts[0].trim())),
+            normalize(Double.parseDouble(parts[1].trim()))
+        ));
+      } catch (NumberFormatException e) {
+        LOG.warn("Ignoring entry '{}' in vehicle.invalid.locations - not a numeric coordinate pair", trimmed);
+      }
+    }
+    return coordinates;
+  }
+
+  /**
+   * {@code -0.0} and {@code 0.0} are distinct values to {@code Double.equals}, so a feed
+   * reporting {@code -0.0} would not match a configured {@code 0.0} without this.
+   */
+  private static double normalize(double value) {
+    return value == 0.0 ? 0.0 : value;
+  }
+
+  private record Coordinate(double latitude, double longitude) {
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -63,3 +63,9 @@ vehicle.sx.republish.chunk.delay=PT0.05S
 # journeys - a major interchange, a stop place or a whole network can match a large fraction of
 # the map. Emission is never capped or dropped on this - the WARN is only an operability signal.
 vehicle.sx.republish.large.fanout.threshold=2000
+
+# Coordinates reported by upstream producers for vehicles whose real position is unknown.
+# Comma-separated latitude/longitude pairs, matched exactly. Vehicles at these coordinates are
+# still stored and still queryable, but are only returned when a client passes
+# includeInvalidLocations: true.
+vehicle.invalid.locations=0.0/0.0,-1.0/-1.0,1.0/1.0

--- a/src/main/resources/graphql/vehicle-updates.graphqls
+++ b/src/main/resources/graphql/vehicle-updates.graphqls
@@ -29,7 +29,10 @@ type Query {
         monitored: Boolean
         boundingBox: BoundingBox
         # Maximum age of data in the response as Duration (e.g. `PT1M`). If lastUpdated is older than this, it will not be included in the response.
-        maxDataAge: Duration,) : [VehicleUpdate]
+        maxDataAge: Duration,
+        # Include vehicles whose reported coordinates are known to be invalid (e.g. 0,0).
+        # Such vehicles are excluded by default.
+        includeInvalidLocations: Boolean = false) : [VehicleUpdate]
 
 
     timetables(
@@ -91,6 +94,9 @@ type Subscription {
                    boundingBox: BoundingBox,
                    # Maximum age of data in the response as Duration (e.g. `PT1M`). If lastUpdated is older than this, it will not be included in the initial response.
                    maxDataAge: Duration,
+                   # Include vehicles whose reported coordinates are known to be invalid (e.g. 0,0).
+                   # Such vehicles are excluded by default.
+                   includeInvalidLocations: Boolean = false
                    # Number of updates buffered before data is pushed. May be used in combination with bufferTime.
                    bufferSize: Int = 20
                    # How long - in milliseconds - data is buffered before data is pushed. May be used in combination with bufferSize.

--- a/src/main/resources/graphql/vehicle-updates.graphqls
+++ b/src/main/resources/graphql/vehicle-updates.graphqls
@@ -30,8 +30,10 @@ type Query {
         boundingBox: BoundingBox
         # Maximum age of data in the response as Duration (e.g. `PT1M`). If lastUpdated is older than this, it will not be included in the response.
         maxDataAge: Duration,
-        # Include vehicles whose reported coordinates are known to be invalid (e.g. 0,0).
-        # Such vehicles are excluded by default.
+        """
+        Include vehicles whose reported coordinates are known to be invalid (e.g. 0,0).
+        Such vehicles are excluded by default.
+        """
         includeInvalidLocations: Boolean = false) : [VehicleUpdate]
 
 
@@ -94,8 +96,10 @@ type Subscription {
                    boundingBox: BoundingBox,
                    # Maximum age of data in the response as Duration (e.g. `PT1M`). If lastUpdated is older than this, it will not be included in the initial response.
                    maxDataAge: Duration,
-                   # Include vehicles whose reported coordinates are known to be invalid (e.g. 0,0).
-                   # Such vehicles are excluded by default.
+                   """
+                   Include vehicles whose reported coordinates are known to be invalid (e.g. 0,0).
+                   Such vehicles are excluded by default.
+                   """
                    includeInvalidLocations: Boolean = false
                    # Number of updates buffered before data is pushed. May be used in combination with bufferTime.
                    bufferSize: Int = 20

--- a/src/test/java/org/entur/vehicles/data/QueryFilterTest.java
+++ b/src/test/java/org/entur/vehicles/data/QueryFilterTest.java
@@ -2,8 +2,10 @@ package org.entur.vehicles.data;
 
 import org.entur.vehicles.data.model.Codespace;
 import org.entur.vehicles.data.model.Line;
+import org.entur.vehicles.data.model.Location;
 import org.entur.vehicles.data.model.ServiceJourney;
 import org.entur.vehicles.data.model.ServiceJourneyIdAndDate;
+import org.entur.vehicles.service.InvalidLocationRegistry;
 import org.junit.jupiter.api.Test;
 
 import java.util.Set;
@@ -185,5 +187,78 @@ class QueryFilterTest {
     );
 
     assertFalse(filterNoMatch.isMatch(update));
+  }
+
+  private static QueryFilter emptyFilter() {
+    return new QueryFilter(
+            null,
+            MetricType.QUERY,
+            null, null, null, null, null, null,
+            null, null,
+            null, null, null, null
+    );
+  }
+
+  private static VehicleUpdate vehicleAt(double latitude, double longitude) {
+    VehicleUpdate update = new VehicleUpdate();
+    // NOTE: Location takes (longitude, latitude) - longitude first.
+    update.setLocation(new Location(longitude, latitude));
+    return update;
+  }
+
+  @Test
+  void testInvalidLocationExcludedByDefault() {
+    InvalidLocationRegistry registry = new InvalidLocationRegistry("0.0/0.0,-1.0/-1.0,1.0/1.0");
+    QueryFilter filter = emptyFilter().withLocationValidity(registry, false);
+
+    assertFalse(filter.isMatch(vehicleAt(0.0, 0.0)));
+    assertFalse(filter.isMatch(vehicleAt(-1.0, -1.0)));
+    assertFalse(filter.isMatch(vehicleAt(1.0, 1.0)));
+  }
+
+  @Test
+  void testValidLocationMatchesRegardlessOfFlag() {
+    InvalidLocationRegistry registry = new InvalidLocationRegistry("0.0/0.0,-1.0/-1.0,1.0/1.0");
+
+    assertTrue(emptyFilter().withLocationValidity(registry, false).isMatch(vehicleAt(59.911491, 10.757933)));
+    assertTrue(emptyFilter().withLocationValidity(registry, true).isMatch(vehicleAt(59.911491, 10.757933)));
+  }
+
+  @Test
+  void testInvalidLocationIncludedWhenRequested() {
+    InvalidLocationRegistry registry = new InvalidLocationRegistry("0.0/0.0,-1.0/-1.0,1.0/1.0");
+    QueryFilter filter = emptyFilter().withLocationValidity(registry, true);
+
+    assertTrue(filter.isMatch(vehicleAt(0.0, 0.0)));
+  }
+
+  @Test
+  void testFilterWithoutLocationValidityIsUnchanged() {
+    // Timetable and situation filters - and every pre-existing test - never call
+    // withLocationValidity, and must keep matching invalid locations.
+    assertTrue(emptyFilter().isMatch(vehicleAt(0.0, 0.0)));
+  }
+
+  @Test
+  void testNullRegistryDisablesTheCheck() {
+    assertTrue(emptyFilter().withLocationValidity(null, false).isMatch(vehicleAt(0.0, 0.0)));
+  }
+
+  @Test
+  void testInvalidLocationExcludedEvenWhenOtherCriteriaMatch() {
+    InvalidLocationRegistry registry = new InvalidLocationRegistry("0.0/0.0");
+    QueryFilter filter = new QueryFilter(
+            null,
+            MetricType.QUERY,
+            null, null, null, null, null, null,
+            "TST:Line:123",
+            null,
+            null, null, null, null
+    ).withLocationValidity(registry, false);
+
+    VehicleUpdate update = vehicleAt(0.0, 0.0);
+    update.setLine(new Line("TST:Line:123", "A - B"));
+
+    assertFalse(filter.isMatch(update));
   }
 }

--- a/src/test/java/org/entur/vehicles/graphql/ApplicationGraphQlSchemaTests.java
+++ b/src/test/java/org/entur/vehicles/graphql/ApplicationGraphQlSchemaTests.java
@@ -9,10 +9,14 @@ import org.entur.avro.realtime.siri.model.AffectedVehicleJourneyRecord;
 import org.entur.avro.realtime.siri.model.AffectsRecord;
 import org.entur.avro.realtime.siri.model.EstimatedCallRecord;
 import org.entur.avro.realtime.siri.model.EstimatedVehicleJourneyRecord;
+import org.entur.avro.realtime.siri.model.LocationRecord;
+import org.entur.avro.realtime.siri.model.MonitoredVehicleJourneyRecord;
 import org.entur.avro.realtime.siri.model.PtSituationElementRecord;
+import org.entur.avro.realtime.siri.model.VehicleActivityRecord;
 import org.entur.vehicles.data.model.StopPoint;
 import org.entur.vehicles.repository.SituationRepository;
 import org.entur.vehicles.repository.TimetableRepository;
+import org.entur.vehicles.repository.VehicleRepository;
 import org.entur.vehicles.service.NSRService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -36,6 +40,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -80,6 +85,9 @@ class ApplicationGraphQlSchemaTests {
     @Autowired
     private TimetableRepository timetableRepository;
 
+    @Autowired
+    private VehicleRepository vehicleRepository;
+
     // Every fixture below uses a line/quay/situationNumber unique to its own test. The
     // repositories are shared, mutable, singleton beans that persist state across every test
     // method in this class (and are never reset between them), so a query that isn't scoped
@@ -120,6 +128,18 @@ class ApplicationGraphQlSchemaTests {
     private static final String TAGGED_PLACE_STOP_PLACE = "NSR:StopPlace:tagged-place-probe";
     private static final String TAGGED_PLACE_SITUATION = "TST:SituationNumber:tagged-place-probe";
 
+    private static final String INVALID_LOCATION_QUERY_LINE = "TST:Line:invalid-location-query-probe";
+    private static final String INVALID_LOCATION_QUERY_VALID_VEHICLE = "TST:Vehicle:invalid-location-query-valid";
+    private static final String INVALID_LOCATION_QUERY_INVALID_VEHICLE = "TST:Vehicle:invalid-location-query-invalid";
+
+    private static final String INVALID_LOCATION_SUBSCRIPTION_LINE = "TST:Line:invalid-location-subscription-probe";
+    private static final String INVALID_LOCATION_SUBSCRIPTION_VALID_VEHICLE = "TST:Vehicle:invalid-location-subscription-valid";
+    private static final String INVALID_LOCATION_SUBSCRIPTION_INVALID_VEHICLE = "TST:Vehicle:invalid-location-subscription-invalid";
+
+    private static final String INVALID_LOCATION_SUBSCRIPTION_INCLUDE_LINE = "TST:Line:invalid-location-subscription-include-probe";
+    private static final String INVALID_LOCATION_SUBSCRIPTION_INCLUDE_INVALID_VEHICLE =
+            "TST:Vehicle:invalid-location-subscription-include-invalid";
+
     /**
      * NSR lookup is disabled in the test context, so the real hierarchy is empty and this test
      * has to supply one. It replaces NSRService with a stub whose only knowledge is that the
@@ -149,6 +169,172 @@ class ApplicationGraphQlSchemaTests {
     void contextLoads() {
         // If the schema fails to parse, or a field can't be wired to any resolver/getter,
         // context startup itself fails - this alone is a meaningful assertion.
+    }
+
+    /**
+     * Pins the schema default. {@code VehicleGraphQLTests.queryVehicles} calls the resolver
+     * method directly in Java with a null argument, which only exercises
+     * {@code Boolean.TRUE.equals(null)} - never the SDL default. This executes a real query
+     * document with {@code includeInvalidLocations} omitted, so flipping
+     * {@code Query.vehicles}'s {@code includeInvalidLocations: Boolean = false} to {@code = true}
+     * in vehicle-updates.graphqls makes this fail; a hand-built filter would not.
+     */
+    @Test
+    void vehiclesQueryOmittingTheArgumentExcludesTheKnownInvalidLocation() {
+        vehicleRepository.addAll(List.of(
+                vehicleActivity(INVALID_LOCATION_QUERY_VALID_VEHICLE, INVALID_LOCATION_QUERY_LINE, 59.911491, 10.757933),
+                vehicleActivity(INVALID_LOCATION_QUERY_INVALID_VEHICLE, INVALID_LOCATION_QUERY_LINE, 0.0, 0.0)
+        ));
+
+        String document = """
+                query {
+                  vehicles(lineRef: "%s") {
+                    vehicleId
+                  }
+                }
+                """.formatted(INVALID_LOCATION_QUERY_LINE);
+
+        ExecutionGraphQlResponse response = graphQlService.execute(
+                new DefaultExecutionGraphQlRequest(document, null, Map.of(), Map.of(), "test-invalid-location-query", Locale.ENGLISH)
+        ).block();
+
+        assertThat(response).isNotNull();
+        assertThat(response.getErrors()).isEmpty();
+
+        List<String> vehicleIds = vehicleIdsOf(response.field("vehicles").getValue());
+        assertThat(vehicleIds)
+                .withFailMessage("includeInvalidLocations was omitted from the document, so the schema default "
+                        + "(false) must apply - check Query.vehicles's `includeInvalidLocations: Boolean = false` "
+                        + "in vehicle-updates.graphqls")
+                .containsExactly(INVALID_LOCATION_QUERY_VALID_VEHICLE);
+    }
+
+    /**
+     * Companion to the query test above, and the first test in this class to exercise
+     * {@code Subscription.vehicles} at all - so it also proves the {@code @Argument} name
+     * actually binds to the resolver parameter: Spring GraphQL silently ignores a schema
+     * argument with no matching resolver parameter, so a misspelled {@code @Argument} name would
+     * leave every other test in the suite green.
+     * <p>
+     * The invalid-location vehicle is present before subscribing (covering the initial snapshot,
+     * which flows through the same {@code QueryFilter} as live events - see
+     * {@code VehicleUpdateRxPublisher.getPublisher}) and republished after subscribing (covering
+     * the live path). Neither publish may reach the subscriber.
+     */
+    @Test
+    void vehiclesSubscriptionOmittingTheArgumentExcludesTheKnownInvalidLocationFromSnapshotAndLiveUpdates() throws InterruptedException {
+        vehicleRepository.addAll(List.of(
+                vehicleActivity(INVALID_LOCATION_SUBSCRIPTION_VALID_VEHICLE, INVALID_LOCATION_SUBSCRIPTION_LINE, 59.911491, 10.757933),
+                vehicleActivity(INVALID_LOCATION_SUBSCRIPTION_INVALID_VEHICLE, INVALID_LOCATION_SUBSCRIPTION_LINE, 0.0, 0.0)
+        ));
+
+        String document = """
+                subscription {
+                  vehicles(lineRef: "%s", bufferSize: 1, bufferTime: 50) {
+                    vehicleId
+                  }
+                }
+                """.formatted(INVALID_LOCATION_SUBSCRIPTION_LINE);
+
+        ExecutionGraphQlResponse response = graphQlService.execute(
+                new DefaultExecutionGraphQlRequest(document, null, Map.of(), Map.of(), "test-invalid-location-subscription", Locale.ENGLISH)
+        ).block();
+
+        assertThat(response).isNotNull();
+        assertThat(response.getErrors()).isEmpty();
+
+        Publisher<ExecutionResult> publisher = response.getData();
+        AtomicBoolean invalidVehicleSeen = new AtomicBoolean(false);
+        // Counts down once for the initial snapshot and once for the live republish below - both
+        // must deliver the valid vehicle for this test to prove anything about the invalid one.
+        CountDownLatch validVehicleSeenTwice = new CountDownLatch(2);
+
+        Disposable subscription = Flux.from(publisher).subscribe(result -> {
+            Map<String, Object> data = result.getData();
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> vehicles = (List<Map<String, Object>>) data.get("vehicles");
+            for (Map<String, Object> vehicle : vehicles) {
+                String vehicleId = (String) vehicle.get("vehicleId");
+                if (INVALID_LOCATION_SUBSCRIPTION_INVALID_VEHICLE.equals(vehicleId)) {
+                    invalidVehicleSeen.set(true);
+                } else if (INVALID_LOCATION_SUBSCRIPTION_VALID_VEHICLE.equals(vehicleId)) {
+                    validVehicleSeenTwice.countDown();
+                }
+            }
+        });
+
+        try {
+            // Republished after subscribing - the live path under test, as opposed to the
+            // initial snapshot fixture added above.
+            vehicleRepository.addAll(List.of(
+                    vehicleActivity(INVALID_LOCATION_SUBSCRIPTION_VALID_VEHICLE, INVALID_LOCATION_SUBSCRIPTION_LINE, 59.911491, 10.757934),
+                    vehicleActivity(INVALID_LOCATION_SUBSCRIPTION_INVALID_VEHICLE, INVALID_LOCATION_SUBSCRIPTION_LINE, 0.0, 0.0)
+            ));
+
+            assertThat(validVehicleSeenTwice.await(5, TimeUnit.SECONDS))
+                    .withFailMessage("the valid vehicle must be delivered once in the initial snapshot and once "
+                            + "on the live republish - if this times out, the live delivery path itself is "
+                            + "broken, not just the invalid-location filtering under test")
+                    .isTrue();
+        } finally {
+            subscription.dispose();
+        }
+
+        assertThat(invalidVehicleSeen.get())
+                .withFailMessage("includeInvalidLocations was omitted, so the vehicle at 0,0 must never reach "
+                        + "the subscriber - check Subscription.vehicles's @Argument name and its "
+                        + ".withLocationValidity(...) call")
+                .isFalse();
+    }
+
+    /**
+     * The other half of the pair above: with {@code includeInvalidLocations: true} passed
+     * explicitly, the vehicle at 0,0 must be delivered rather than filtered out.
+     */
+    @Test
+    void vehiclesSubscriptionWithIncludeInvalidLocationsTrueDeliversTheInvalidLocation() throws InterruptedException {
+        vehicleRepository.addAll(List.of(
+                vehicleActivity(INVALID_LOCATION_SUBSCRIPTION_INCLUDE_INVALID_VEHICLE,
+                        INVALID_LOCATION_SUBSCRIPTION_INCLUDE_LINE, 0.0, 0.0)
+        ));
+
+        String document = """
+                subscription {
+                  vehicles(lineRef: "%s", includeInvalidLocations: true, bufferSize: 1, bufferTime: 50) {
+                    vehicleId
+                  }
+                }
+                """.formatted(INVALID_LOCATION_SUBSCRIPTION_INCLUDE_LINE);
+
+        ExecutionGraphQlResponse response = graphQlService.execute(
+                new DefaultExecutionGraphQlRequest(document, null, Map.of(), Map.of(), "test-invalid-location-subscription-include", Locale.ENGLISH)
+        ).block();
+
+        assertThat(response).isNotNull();
+        assertThat(response.getErrors()).isEmpty();
+
+        Publisher<ExecutionResult> publisher = response.getData();
+        CountDownLatch invalidVehicleSeen = new CountDownLatch(1);
+
+        Disposable subscription = Flux.from(publisher).subscribe(result -> {
+            Map<String, Object> data = result.getData();
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> vehicles = (List<Map<String, Object>>) data.get("vehicles");
+            for (Map<String, Object> vehicle : vehicles) {
+                if (INVALID_LOCATION_SUBSCRIPTION_INCLUDE_INVALID_VEHICLE.equals(vehicle.get("vehicleId"))) {
+                    invalidVehicleSeen.countDown();
+                }
+            }
+        });
+
+        try {
+            assertThat(invalidVehicleSeen.await(5, TimeUnit.SECONDS))
+                    .withFailMessage("includeInvalidLocations: true was passed explicitly, so the vehicle at "
+                            + "0,0 must appear in the initial snapshot")
+                    .isTrue();
+        } finally {
+            subscription.dispose();
+        }
     }
 
     @Test
@@ -693,6 +879,32 @@ class ApplicationGraphQlSchemaTests {
         assertThat(affectedStopPoints)
                 .withFailMessage("resolution must not write the resolved quay back onto affects")
                 .isEmpty();
+    }
+
+    private VehicleActivityRecord vehicleActivity(String vehicleRef, String lineRef, double latitude, double longitude) {
+        VehicleActivityRecord record = new VehicleActivityRecord();
+        record.setRecordedAtTime(ZonedDateTime.now().toString());
+        record.setValidUntilTime(ZonedDateTime.now().plusMinutes(10).toString());
+
+        MonitoredVehicleJourneyRecord journey = new MonitoredVehicleJourneyRecord();
+        journey.setDataSource("TST");
+        journey.setLineRef(lineRef);
+        journey.setVehicleRef(vehicleRef);
+        journey.setMonitored(true);
+
+        LocationRecord location = new LocationRecord();
+        location.setLatitude(latitude);
+        location.setLongitude(longitude);
+        journey.setVehicleLocation(location);
+
+        record.setMonitoredVehicleJourney(journey);
+        return record;
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> vehicleIdsOf(Object value) {
+        List<Map<String, Object>> vehicles = (List<Map<String, Object>>) value;
+        return vehicles.stream().map(v -> (String) v.get("vehicleId")).toList();
     }
 
     private PtSituationElementRecord situationAffectingStopPlace(String situationNumber, String stopPlaceRef) {

--- a/src/test/java/org/entur/vehicles/graphql/SituationGraphQLTests.java
+++ b/src/test/java/org/entur/vehicles/graphql/SituationGraphQLTests.java
@@ -87,7 +87,7 @@ public class SituationGraphQLTests {
                 closedSituation()
         ));
 
-        queryService = new Query(null, null, repository, new NSRService(false, null), metricsService);
+        queryService = new Query(null, null, repository, new NSRService(false, null), metricsService, null);
     }
 
     private PtSituationElementRecord baseRecord(String situationNumber) {
@@ -267,7 +267,7 @@ public class SituationGraphQLTests {
         Mockito.when(ancestorAwareNsrService.expandWithAncestors("NSR:Quay:749"))
                 .thenReturn(Set.of("NSR:Quay:749", "NSR:StopPlace:451"));
 
-        Query ancestorQueryService = new Query(null, null, repository, ancestorAwareNsrService, metricsService);
+        Query ancestorQueryService = new Query(null, null, repository, ancestorAwareNsrService, metricsService, null);
 
         Collection<SituationUpdate> situations = ancestorQueryService.getSituations(
                 null, null, null, null, "NSR:Quay:749", null, null, null, null, null, null, null, null, null);

--- a/src/test/java/org/entur/vehicles/graphql/TimetableGraphQLTests.java
+++ b/src/test/java/org/entur/vehicles/graphql/TimetableGraphQLTests.java
@@ -51,7 +51,7 @@ public class TimetableGraphQLTests {
                 publisher
         );
         publisher = new EstimatedTimetableUpdateRxPublisher();
-        queryService = new Query(null, repository, null, new NSRService(false, null), metricsService);
+        queryService = new Query(null, repository, null, new NSRService(false, null), metricsService, null);
 
         EstimatedVehicleJourneyRecord journeyRecord = new EstimatedVehicleJourneyRecord();
         journeyRecord.setLineRef("TST:Line:123");

--- a/src/test/java/org/entur/vehicles/graphql/VehicleGraphQLTests.java
+++ b/src/test/java/org/entur/vehicles/graphql/VehicleGraphQLTests.java
@@ -6,6 +6,7 @@ import org.entur.avro.realtime.siri.model.FramedVehicleJourneyRefRecord;
 import org.entur.avro.realtime.siri.model.LocationRecord;
 import org.entur.avro.realtime.siri.model.MonitoredVehicleJourneyRecord;
 import org.entur.avro.realtime.siri.model.VehicleActivityRecord;
+import org.entur.vehicles.data.VehicleUpdate;
 import org.entur.vehicles.data.model.Codespace;
 import org.entur.vehicles.data.model.DatedServiceJourney;
 import org.entur.vehicles.data.model.Line;
@@ -14,6 +15,7 @@ import org.entur.vehicles.graphql.publishers.VehicleUpdateRxPublisher;
 import org.entur.vehicles.metrics.PrometheusMetricsService;
 import org.entur.vehicles.repository.AutoPurgingVehicleMap;
 import org.entur.vehicles.repository.VehicleRepository;
+import org.entur.vehicles.service.InvalidLocationRegistry;
 import org.entur.vehicles.service.LineService;
 import org.entur.vehicles.service.NSRService;
 import org.entur.vehicles.service.ServiceJourneyService;
@@ -23,6 +25,7 @@ import org.mockito.Mockito;
 
 import java.time.Duration;
 import java.time.ZonedDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
@@ -51,7 +54,8 @@ public class VehicleGraphQLTests {
                 publisher
         );
         publisher = new VehicleUpdateRxPublisher();
-        queryService = new Query(repository, null, null, new NSRService(false, null), metricsService);
+        queryService = new Query(repository, null, null, new NSRService(false, null), metricsService,
+                new InvalidLocationRegistry("0.0/0.0,-1.0/-1.0,1.0/1.0"));
 
         VehicleActivityRecord vehicleActivityRecord = new VehicleActivityRecord();
         vehicleActivityRecord.setRecordedAtTime(ZonedDateTime.now().toString());
@@ -152,5 +156,67 @@ public class VehicleGraphQLTests {
         ServiceJourney serviceJourney1 = queryService.serviceJourney("DSJ:DatedServiceJourney:1234567890");
         ServiceJourney dsj_serviceJourney1 = queryService.serviceJourney("DSJ:ServiceJourney:1234567890");
         assertEquals(serviceJourney1, dsj_serviceJourney1);
+    }
+
+    private VehicleActivityRecord createVehicleActivity(String codespace, String vehicleRef, String lineRef,
+                                                        double latitude, double longitude) {
+        VehicleActivityRecord record = new VehicleActivityRecord();
+        record.setRecordedAtTime(ZonedDateTime.now().toString());
+        record.setValidUntilTime(ZonedDateTime.now().plusMinutes(10).toString());
+
+        MonitoredVehicleJourneyRecord journey = new MonitoredVehicleJourneyRecord();
+        journey.setLineRef(lineRef);
+        journey.setVehicleRef(vehicleRef);
+        journey.setMonitored(true);
+        journey.setDataSource(codespace);
+
+        LocationRecord location = new LocationRecord();
+        location.setLatitude(latitude);
+        location.setLongitude(longitude);
+        journey.setVehicleLocation(location);
+
+        record.setMonitoredVehicleJourney(journey);
+        return record;
+    }
+
+    private Collection<VehicleUpdate> queryVehicles(String codespaceId, Boolean includeInvalidLocations) {
+        return queryService.getVehicles(
+                null,   // serviceJourneyId
+                null,   // date
+                null,   // serviceJourneyIdAndDates
+                null,   // datedServiceJourneyId
+                null,   // datedServiceJourneyIds
+                null,   // operatorRef
+                codespaceId,
+                null,   // mode
+                null,   // vehicleId
+                null,   // vehicleIds
+                null,   // lineRef
+                null,   // lineName
+                null,   // monitored
+                null,   // boundingBox
+                null,   // maxDataAge
+                includeInvalidLocations
+        );
+    }
+
+    @Test
+    public void testInvalidLocationsAreExcludedUnlessRequested() {
+        repository.addAll(List.of(
+                createVehicleActivity("INV", "INV:Vehicle:valid", "INV:Line:1", 59.911491, 10.757933),
+                createVehicleActivity("INV", "INV:Vehicle:invalid", "INV:Line:1", 0.0, 0.0)
+        ));
+
+        // Argument omitted by the client - GraphQL applies the schema default of false
+        Collection<VehicleUpdate> defaultResult = queryVehicles("INV", null);
+        assertEquals(1, defaultResult.size());
+        assertEquals("INV:Vehicle:valid", defaultResult.iterator().next().getVehicleId());
+
+        Collection<VehicleUpdate> explicitlyExcluded = queryVehicles("INV", false);
+        assertEquals(1, explicitlyExcluded.size());
+
+        Collection<VehicleUpdate> included = queryVehicles("INV", true);
+        assertEquals(2, included.size());
+        assertTrue(included.stream().anyMatch(v -> "INV:Vehicle:invalid".equals(v.getVehicleId())));
     }
 }

--- a/src/test/java/org/entur/vehicles/service/InvalidLocationRegistryTest.java
+++ b/src/test/java/org/entur/vehicles/service/InvalidLocationRegistryTest.java
@@ -1,0 +1,96 @@
+package org.entur.vehicles.service;
+
+import org.entur.vehicles.data.model.Location;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InvalidLocationRegistryTest {
+
+  private static final String DEFAULT_CONFIG = "0.0/0.0,-1.0/-1.0,1.0/1.0";
+
+  // NOTE: Location takes (longitude, latitude) - longitude first.
+  private static Location location(double latitude, double longitude) {
+    return new Location(longitude, latitude);
+  }
+
+  @Test
+  void theDefaultConfiguredCoordinatesAreInvalid() {
+    InvalidLocationRegistry registry = new InvalidLocationRegistry(DEFAULT_CONFIG);
+
+    assertThat(registry.isInvalid(location(0.0, 0.0))).isTrue();
+    assertThat(registry.isInvalid(location(-1.0, -1.0))).isTrue();
+    assertThat(registry.isInvalid(location(1.0, 1.0))).isTrue();
+  }
+
+  @Test
+  void aRealCoordinateIsValid() {
+    InvalidLocationRegistry registry = new InvalidLocationRegistry(DEFAULT_CONFIG);
+
+    // Oslo
+    assertThat(registry.isInvalid(location(59.911491, 10.757933))).isFalse();
+  }
+
+  @Test
+  void aCoordinateMatchingOnlyOneComponentIsValid() {
+    InvalidLocationRegistry registry = new InvalidLocationRegistry(DEFAULT_CONFIG);
+
+    assertThat(registry.isInvalid(location(0.0, 10.757933))).isFalse();
+    assertThat(registry.isInvalid(location(59.911491, 0.0))).isFalse();
+  }
+
+  @Test
+  void negativeZeroMatchesAConfiguredZero() {
+    InvalidLocationRegistry registry = new InvalidLocationRegistry(DEFAULT_CONFIG);
+
+    assertThat(registry.isInvalid(location(-0.0, -0.0))).isTrue();
+  }
+
+  @Test
+  void aNullLocationIsValid() {
+    InvalidLocationRegistry registry = new InvalidLocationRegistry(DEFAULT_CONFIG);
+
+    assertThat(registry.isInvalid(null)).isFalse();
+  }
+
+  @Test
+  void aLocationWithNullComponentsIsValid() {
+    InvalidLocationRegistry registry = new InvalidLocationRegistry(DEFAULT_CONFIG);
+
+    Location location = location(0.0, 0.0);
+    location.setLatitude(null);
+
+    assertThat(registry.isInvalid(location)).isFalse();
+  }
+
+  @Test
+  void aCustomConfigurationReplacesTheDefaults() {
+    InvalidLocationRegistry registry = new InvalidLocationRegistry("12.5/13.5");
+
+    assertThat(registry.isInvalid(location(12.5, 13.5))).isTrue();
+    assertThat(registry.isInvalid(location(0.0, 0.0))).isFalse();
+  }
+
+  @Test
+  void whitespaceAroundEntriesIsIgnored() {
+    InvalidLocationRegistry registry = new InvalidLocationRegistry("  0.0 / 0.0 ,  1.0/1.0  ");
+
+    assertThat(registry.isInvalid(location(0.0, 0.0))).isTrue();
+    assertThat(registry.isInvalid(location(1.0, 1.0))).isTrue();
+  }
+
+  @Test
+  void aMalformedEntryIsSkippedAndTheRestStillParsed() {
+    InvalidLocationRegistry registry = new InvalidLocationRegistry("0.0/0.0,not-a-coordinate,7.0/8.0/9.0,1.0/1.0");
+
+    assertThat(registry.isInvalid(location(0.0, 0.0))).isTrue();
+    assertThat(registry.isInvalid(location(1.0, 1.0))).isTrue();
+  }
+
+  @Test
+  void anEmptyConfigurationDisablesTheRegistry() {
+    InvalidLocationRegistry registry = new InvalidLocationRegistry("");
+
+    assertThat(registry.isInvalid(location(0.0, 0.0))).isFalse();
+  }
+}

--- a/src/test/java/org/entur/vehicles/service/InvalidLocationRegistryTest.java
+++ b/src/test/java/org/entur/vehicles/service/InvalidLocationRegistryTest.java
@@ -63,6 +63,22 @@ class InvalidLocationRegistryTest {
     assertThat(registry.isInvalid(location)).isFalse();
   }
 
+  /**
+   * The symmetric case to {@link #aLocationWithNullComponentsIsValid()}: a null longitude with a
+   * non-null latitude. {@code isInvalid} unboxes both {@code getLatitude()} and
+   * {@code getLongitude()} - if the null guard only checked latitude twice (by mistake), this
+   * would NPE instead of returning false.
+   */
+  @Test
+  void aLocationWithNullLongitudeIsValid() {
+    InvalidLocationRegistry registry = new InvalidLocationRegistry(DEFAULT_CONFIG);
+
+    Location location = location(0.0, 0.0);
+    location.setLongitude(null);
+
+    assertThat(registry.isInvalid(location)).isFalse();
+  }
+
   @Test
   void aCustomConfigurationReplacesTheDefaults() {
     InvalidLocationRegistry registry = new InvalidLocationRegistry("12.5/13.5");


### PR DESCRIPTION
Users reported vehicles at coordinates `0,0`, `-1,-1` and `1,1` showing up in the API  - upstream producers send these when a vehicle's real position is unknown, and they render as vehicles floating off the coast of Africa in map clients.

The data still has to be stored and retrievable, so this makes it opt-in rather than dropping it.


Replaces proposed PR at https://github.com/entur/anshar/pull/244